### PR TITLE
Mnemonic / wallet deletion needs to be async

### DIFF
--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -85,7 +85,7 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
   }
 
   void deleteAccount() async {
-    AccountsUtil.getInstance().permanentlyDeleteAccount();
+    await AccountsUtil.getInstance().permanentlyDeleteAccount();
   }
 
   void revealMnemonic() async {

--- a/lib/account.dart
+++ b/lib/account.dart
@@ -51,14 +51,14 @@ class AccountsUtil {
 
   Future<String?> getAccountAddress() async {
     final wallet = await getWallet();
-    if(wallet == null) {
+    if (wallet == null) {
       return null;
     }
     return wallet.address.hex;
   }
 
-  void permanentlyDeleteAccount() {
-    _keyManager.deleteMnemonic();
+  Future<void> permanentlyDeleteAccount() async {
+    await _keyManager.deleteMnemonic();
     _cachedWallet = null;
   }
 
@@ -102,9 +102,9 @@ class AccountsUtil {
   }
 
   Future<EthPrivateKey> _makeWalletFromMnemonic(String mnemonic) async {
-    Uint8List privateKey = await _keyManager.makePrivateKeyFromMnemonic(mnemonic);
+    Uint8List privateKey =
+        await _keyManager.makePrivateKeyFromMnemonic(mnemonic);
     String hexCode = "0x${bytesToHex(privateKey)}";
     return EthPrivateKey.fromHex(hexCode);
   }
-
 }

--- a/lib/key_manager.dart
+++ b/lib/key_manager.dart
@@ -6,7 +6,7 @@ abstract class KeyManager {
   Future<String?> getMnemonic();
   Future<String?> generateMnemonic();
   void saveMnemonic(String mnemonic, {KeyStorageConfig? options});
-  void deleteMnemonic();
+  Future<void> deleteMnemonic();
   Future<Uint8List> makePrivateKeyFromMnemonic(String mnemonic);
   Future<Uint8List> getStoredPrivateKey();
 }
@@ -29,8 +29,8 @@ class KeyManagerImpl extends KeyManager {
   final methodChannel = const MethodChannel('rly_network_flutter_sdk');
 
   @override
-  void deleteMnemonic() {
-    methodChannel.invokeMethod<bool>("deleteMnemonic");
+  Future<void> deleteMnemonic() async {
+    await methodChannel.invokeMethod<bool>("deleteMnemonic");
   }
 
   @override


### PR DESCRIPTION
Anything that goes through the native bridge is async. Hiding that fact
from devs sets them up for super confusing race condition bugs.
