### PR TITLE
Saving of mnemonic also needs to be exposed as async

### DIFF
--- a/lib/account.dart
+++ b/lib/account.dart
@@ -25,7 +25,7 @@ class AccountsUtil {
     }
 
     final mnemonic = await _keyManager.generateMnemonic();
-    _keyManager.saveMnemonic(mnemonic!);
+    await _keyManager.saveMnemonic(mnemonic!);
     final newWallet = await _makeWalletFromMnemonic(mnemonic);
 
     _cachedWallet = newWallet;

--- a/lib/key_manager.dart
+++ b/lib/key_manager.dart
@@ -5,7 +5,7 @@ import 'keyStorageConfig.dart';
 abstract class KeyManager {
   Future<String?> getMnemonic();
   Future<String?> generateMnemonic();
-  void saveMnemonic(String mnemonic, {KeyStorageConfig? options});
+  Future<void> saveMnemonic(String mnemonic, {KeyStorageConfig? options});
   Future<void> deleteMnemonic();
   Future<Uint8List> makePrivateKeyFromMnemonic(String mnemonic);
   Future<Uint8List> getStoredPrivateKey();
@@ -37,7 +37,7 @@ class KeyManagerImpl extends KeyManager {
   Future<String?> generateMnemonic() async {
     String? mnemonic =
         await methodChannel.invokeMethod<String>("generateNewMnemonic");
-    saveMnemonic(mnemonic!);
+    await saveMnemonic(mnemonic!);
     return mnemonic;
   }
 


### PR DESCRIPTION
Noticed another case where race conditions and other nasty bugs were
likely to happen because async nature of bridge was not being respected.
