### PR TITLE
Ensure necessary maven repo gets injected into consuming apps build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     }
 }
 
-allprojects {
+rootProject.allprojects {
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
The way flutter builds projects with plugins that include native code, is to pull in the source code as subprojects. If the SDK needs a specific maven repository to exist for the consuming app to be able to call our code, then we have to tell gradle to inject that setting into the rootProject which is basically the 3rd party app consuming our SDK
