### PR TITLE
Wallet creation API should return a wallet object

### DIFF
--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -7,11 +7,11 @@ import 'package:url_launcher/url_launcher.dart';
 final rlyNetwork = rlyMumbaiNetwork;
 
 class AccountOverviewScreen extends StatefulWidget {
-  final String rlyAccount;
+  final String walletAddress;
   final VoidCallback onAccountDeleted;
 
   const AccountOverviewScreen(
-      {super.key, required this.rlyAccount, required this.onAccountDeleted});
+      {super.key, required this.walletAddress, required this.onAccountDeleted});
 
   @override
   AccountOverviewScreenState createState() => AccountOverviewScreenState();
@@ -140,7 +140,7 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
                               style: TextStyle(
                                   fontWeight: FontWeight.bold, fontSize: 18)),
                           const SizedBox(height: 12),
-                          Text(widget.rlyAccount,
+                          Text(widget.walletAddress,
                               style: const TextStyle(
                                 fontWeight: FontWeight.bold,
                               )),
@@ -150,7 +150,7 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
                           FullWidthButton(
                             onPressed: () async {
                               await launchUrl(Uri.parse(
-                                  'https://mumbai.polygonscan.com/address/${widget.rlyAccount}'));
+                                  'https://mumbai.polygonscan.com/address/${widget.walletAddress}'));
                             },
                             child: const Text('View on Polygon'),
                           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:web3dart/web3dart.dart';
 
 import 'account_overview_screen.dart';
 import 'GenerateAccountScreen.dart';
@@ -14,7 +15,7 @@ class App extends StatefulWidget {
 
 class AppState extends State<App> {
   bool _accountLoaded = false;
-  String? _rlyAccount;
+  EthPrivateKey? _rlyAccount;
 
   @override
   void initState() {
@@ -23,7 +24,7 @@ class AppState extends State<App> {
   }
 
   Future<void> _readAccount() async {
-    final account = await AccountsUtil.getInstance().getAccountAddress();
+    final account = await AccountsUtil.getInstance().getWallet();
     setState(() {
       _accountLoaded = true;
       if (account != null) {
@@ -57,12 +58,13 @@ class AppState extends State<App> {
     }
 
     return AccountOverviewScreen(
-        rlyAccount: _rlyAccount!, onAccountDeleted: _clearAccount);
+        walletAddress: _rlyAccount!.address.hex,
+        onAccountDeleted: _clearAccount);
   }
 }
 
 void main() {
-  runApp(MaterialApp(
+  runApp(const MaterialApp(
     home: App(),
   ));
 }

--- a/lib/account.dart
+++ b/lib/account.dart
@@ -18,7 +18,7 @@ class AccountsUtil {
     return _instance;
   }
 
-  Future<String> createAccount({bool overwrite = false}) async {
+  Future<EthPrivateKey> createAccount({bool overwrite = false}) async {
     final existingWallet = await getWallet();
     if (existingWallet != null && !overwrite) {
       throw 'Account already exists';
@@ -29,7 +29,7 @@ class AccountsUtil {
     final newWallet = await _makeWalletFromMnemonic(mnemonic);
 
     _cachedWallet = newWallet;
-    return newWallet.address.hex;
+    return newWallet;
   }
 
   Future<EthPrivateKey?> getWallet() async {


### PR DESCRIPTION
We had the wallet object already initialized and were choosing to return
just an address. This added an unnecessary extra step of having to call
getWallet if you wanted to use the newly created wallet. Now you can
skip the extra promise step by getting the wallet directly.

Previously if you wanted to have an object you could sign with right after creation you'd have to do: 
```
await createAccount();
final wallet = await getWallet();
```

Now with this change you can do: 
```
final wallet = await createAccount();