### PR TITLE
More cleanup of key manager code

### DIFF
--- a/lib/account.dart
+++ b/lib/account.dart
@@ -103,7 +103,7 @@ class AccountsUtil {
 
   Future<EthPrivateKey> _makeWalletFromMnemonic(String mnemonic) async {
     Uint8List privateKey =
-        await _keyManager.makePrivateKeyFromMnemonic(mnemonic);
+        await _keyManager.getPrivateKeyFromMnemonic(mnemonic);
     String hexCode = "0x${bytesToHex(privateKey)}";
     return EthPrivateKey.fromHex(hexCode);
   }

--- a/lib/account.dart
+++ b/lib/account.dart
@@ -25,7 +25,7 @@ class AccountsUtil {
     }
 
     final mnemonic = await _keyManager.generateMnemonic();
-    await _keyManager.saveMnemonic(mnemonic!);
+    await _keyManager.saveMnemonic(mnemonic);
     final newWallet = await _makeWalletFromMnemonic(mnemonic);
 
     _cachedWallet = newWallet;

--- a/lib/account.dart
+++ b/lib/account.dart
@@ -12,7 +12,7 @@ class AccountsUtil {
 
   AccountsUtil(this._keyManager);
 
-  static final AccountsUtil _instance = AccountsUtil(KeyManagerImpl());
+  static final AccountsUtil _instance = AccountsUtil(KeyManager());
 
   factory AccountsUtil.getInstance() {
     return _instance;

--- a/lib/key_manager.dart
+++ b/lib/key_manager.dart
@@ -4,7 +4,7 @@ import 'key_storage_config.dart';
 
 abstract class KeyManager {
   Future<String?> getMnemonic();
-  Future<String?> generateMnemonic();
+  Future<String> generateMnemonic();
   Future<void> saveMnemonic(String mnemonic, {KeyStorageConfig? options});
   Future<void> deleteMnemonic();
   Future<Uint8List> makePrivateKeyFromMnemonic(String mnemonic);
@@ -19,10 +19,15 @@ class KeyManagerImpl extends KeyManager {
   }
 
   @override
-  Future<String?> generateMnemonic() async {
+  Future<String> generateMnemonic() async {
     String? mnemonic =
         await methodChannel.invokeMethod<String>("generateNewMnemonic");
-    await saveMnemonic(mnemonic!);
+
+    if (mnemonic == null) {
+      throw Exception(
+          "Unable to generate mnemonic, something went wrong at native code layer");
+    }
+
     return mnemonic;
   }
 

--- a/lib/key_manager.dart
+++ b/lib/key_manager.dart
@@ -2,23 +2,13 @@ import 'package:flutter/services.dart';
 
 import 'key_storage_config.dart';
 
-abstract class KeyManager {
-  Future<String?> getMnemonic();
-  Future<String> generateMnemonic();
-  Future<void> saveMnemonic(String mnemonic, {KeyStorageConfig? options});
-  Future<void> deleteMnemonic();
-  Future<Uint8List> getPrivateKeyFromMnemonic(String mnemonic);
-}
-
-class KeyManagerImpl extends KeyManager {
+class KeyManager {
   final methodChannel = const MethodChannel('rly_network_flutter_sdk');
 
-  @override
   Future<void> deleteMnemonic() async {
     await methodChannel.invokeMethod<bool>("deleteMnemonic");
   }
 
-  @override
   Future<String> generateMnemonic() async {
     String? mnemonic =
         await methodChannel.invokeMethod<String>("generateNewMnemonic");
@@ -31,13 +21,11 @@ class KeyManagerImpl extends KeyManager {
     return mnemonic;
   }
 
-  @override
   Future<String?> getMnemonic() async {
     String? mnemonic = await methodChannel.invokeMethod<String>("getMnemonic");
     return mnemonic;
   }
 
-  @override
   Future<Uint8List> getPrivateKeyFromMnemonic(String mnemonic) async {
     List<Object?>? pvtKey = await methodChannel
         .invokeMethod<List<Object?>>("getPrivateKeyFromMnemonic", {
@@ -47,7 +35,6 @@ class KeyManagerImpl extends KeyManager {
     return privateKey;
   }
 
-  @override
   Future<void> saveMnemonic(String mnemonic,
       {KeyStorageConfig? options}) async {
     if (options == null || !options.saveToCloud) {

--- a/lib/key_manager.dart
+++ b/lib/key_manager.dart
@@ -7,7 +7,7 @@ abstract class KeyManager {
   Future<String> generateMnemonic();
   Future<void> saveMnemonic(String mnemonic, {KeyStorageConfig? options});
   Future<void> deleteMnemonic();
-  Future<Uint8List> makePrivateKeyFromMnemonic(String mnemonic);
+  Future<Uint8List> getPrivateKeyFromMnemonic(String mnemonic);
 }
 
 class KeyManagerImpl extends KeyManager {
@@ -38,7 +38,7 @@ class KeyManagerImpl extends KeyManager {
   }
 
   @override
-  Future<Uint8List> makePrivateKeyFromMnemonic(String mnemonic) async {
+  Future<Uint8List> getPrivateKeyFromMnemonic(String mnemonic) async {
     List<Object?>? pvtKey = await methodChannel
         .invokeMethod<List<Object?>>("getPrivateKeyFromMnemonic", {
       'mnemonic': mnemonic,


### PR DESCRIPTION
- Low level mnemonic generation should never return null
- Rename method for better understanding of what it actually does
- Simplify key manager class hierarchy
