### PR TITLE
Add support for configurable cloud syncing of keys

### DIFF
--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/FlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/FlutterSdkPlugin.kt
@@ -77,8 +77,8 @@ class FlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
 
   private fun saveMnemonic(call: MethodCall, result: Result) {
     val mnemonic = call.argument<String>("mnemonic") ?: ""
-    val useBlockStore = call.argument<Boolean>("useBlockStore")?: false
-    val forceBlockStore = call.argument<Boolean>("forceBlockStore")?: false
+    val useBlockStore = call.argument<Boolean>("saveToCloud")?: false
+    val forceBlockStore = call.argument<Boolean>("rejectOnCloudSaveFailure")?: false
 
     if (!MnemonicWords(mnemonic).validate(WORDLIST_ENGLISH)) {
       result.error("mnemonic_verification_failure", "Mnemonic is not valid", null)

--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
@@ -2,17 +2,10 @@ package com.rlynetworkmobilesdk
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import androidx.security.crypto.MasterKey.Builder
-import com.google.android.gms.auth.blockstore.Blockstore
-import com.google.android.gms.auth.blockstore.BlockstoreClient
-import com.google.android.gms.auth.blockstore.DeleteBytesRequest
-import com.google.android.gms.auth.blockstore.RetrieveBytesRequest
-import com.google.android.gms.auth.blockstore.RetrieveBytesResponse
-import com.google.android.gms.auth.blockstore.StoreBytesData
-import kotlin.math.log
+import com.google.android.gms.auth.blockstore.*
 
 class MnemonicStorageHelper(context: Context) {
     private val sharedPreferences: SharedPreferences
@@ -39,17 +32,7 @@ class MnemonicStorageHelper(context: Context) {
     }
 
     fun save(key: String, mnemonic: String, useBlockStore: Boolean, forceBlockStore: Boolean, onSuccess: () -> Unit, onFailure: (message: String) -> Unit) {
-        //Todo: remove hardcoding of this isEndToEndEncryptionAvailable flag
-        //original logic form the rly sdk requires that we store on blockstore only if end to end encryption is there
-        //figure out how and when this end to end encryption will be available so that we can start storing mnemonic on the block store
-        //in case end-to-end encryption isn't available we have a few options:
-        // 1. save mnemonic on local storage -> todo: currently shared pref is used, use secure storage instead
-        //2. save on block store without end to end encryption
-        //3. save mnemonic only on our server
-        // discuss all options and decide
-        isEndToEndEncryptionAvailable = true
         if (useBlockStore && isEndToEndEncryptionAvailable) {
-            Log.i("memonic_storage", "saving on cloud , because useBlockStore = true and isEndToEndEncryptionAvailable = true")
             val storeRequest = StoreBytesData.Builder()
                 .setBytes(mnemonic.toByteArray(Charsets.UTF_8))
                 .setKey(key)
@@ -58,18 +41,14 @@ class MnemonicStorageHelper(context: Context) {
 
             blockstoreClient.storeBytes(storeRequest.build())
                 .addOnSuccessListener {
-                    Log.i("memonic_storage", "saved on cloud")
                     onSuccess()
                 }.addOnFailureListener { e ->
-                    Log.i("memonic_storage", "failed to save on cloud")
                     onFailure("Failed to save to cloud $e")
                 }
         } else {
             if (forceBlockStore) {
-                Log.i("memonic_storage", "forceBlockStore = true")
                 onFailure("Failed to save mnemonic. No end to end encryption option is available and force cloud is on");
             } else {
-                Log.i("memonic_storage", "saving mnemonic on local")
                 saveToSharedPref(key, mnemonic)
                 onSuccess()
             }
@@ -93,16 +72,12 @@ class MnemonicStorageHelper(context: Context) {
                 val blockstoreDataMap = result.blockstoreDataMap
 
                 if (blockstoreDataMap.isEmpty()) {
-                    Log.i("memonic_storage", "got empty from block store, reading from shared prefs")
                     val mnemonic = readFromSharedPref(key)
                     onSuccess(mnemonic)
                 } else {
                     val mnemonic = blockstoreDataMap[key]
-                    Log.i("memonic_storage", "got non-empty from block store")
                     if (mnemonic !== null) {
-                        val strMnemonic = mnemonic.bytes.toString(Charsets.UTF_8)
-                        Log.i("memonic_storage", "got non-empty from block store $strMnemonic")
-                        onSuccess(strMnemonic)
+                        onSuccess(mnemonic.bytes.toString(Charsets.UTF_8))
                     } else {
                         onSuccess(null)
                     }

--- a/ios/Classes/FlutterSdkPlugin.swift
+++ b/ios/Classes/FlutterSdkPlugin.swift
@@ -11,35 +11,33 @@ public class FlutterSdkPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-   
     switch call.method {
-      
-    case "getPlatformVersion":
-      result("iOS " + UIDevice.current.systemVersion)
-    case "generateNewMnemonic":
-      result(RlyNetworkMobileSdk().generateMnemonic())
-    case "getPrivateKeyFromMnemonic":
-      if let arguments = call.arguments as? [String: Any], let data = arguments["mnemonic"] as? String {
-        result(RlyNetworkMobileSdk().getPrivateKeyFromMnemonic(data))
-    } else {
-        // Handle the case where 'arguments' or 'data' is nil
-        // You might want to return an error or a default value here.
-    }
-      case "getMnemonic":
-        result(RlyNetworkMobileSdk().getMnemonic())
-      case "deleteMnemonic":
-        result(RlyNetworkMobileSdk().deleteMnemonic())
-      
-      case "saveMnemonic":
-        if let arguments = call.arguments as? [String: Any], let mnemonicToSave = arguments["mnemonic"] as? String {
-          result(RlyNetworkMobileSdk().saveMnemonic(mnemonicToSave,saveToCloud: true, rejectOnCloudSaveFailure: true))
+      case "getPlatformVersion":
+        result("iOS " + UIDevice.current.systemVersion)
+      case "generateNewMnemonic":
+        result(RlyNetworkMobileSdk().generateMnemonic())
+      case "getPrivateKeyFromMnemonic":
+        if let arguments = call.arguments as? [String: Any], let data = arguments["mnemonic"] as? String {
+          result(RlyNetworkMobileSdk().getPrivateKeyFromMnemonic(data))
+        } else {
+            // Handle the case where 'arguments' or 'data' is nil
+            // You might want to return an error or a default value here.
         }
+        case "getMnemonic":
+          result(RlyNetworkMobileSdk().getMnemonic())
+        case "deleteMnemonic":
+          result(RlyNetworkMobileSdk().deleteMnemonic())
 
-      // let arguments = call.arguments as [String: Any]
-      // let data = arguments["mnemonic"] as String
-      // result(RlyNetworkMobileSdk().getPrivateKeyFromMnemonic(mnemonic: data))
-    default:
-      result(FlutterMethodNotImplemented)
+        case "saveMnemonic":
+          if let arguments = call.arguments as? [String: Any],
+            let mnemonicToSave = arguments["mnemonic"] as? String,
+            let saveToCloud = arguments["saveToCloud"] as? Bool,
+            let rejectOnCloudSaveFailure = arguments["rejectOnCloudSaveFailure"] as? Bool {
+            result(RlyNetworkMobileSdk().saveMnemonic(mnemonicToSave, saveToCloud: saveToCloud, rejectOnCloudSaveFailure: rejectOnCloudSaveFailure))
+          }
+
+        default:
+          result(FlutterMethodNotImplemented)
     }
   }
 }

--- a/lib/account.dart
+++ b/lib/account.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:eth_sig_util/util/utils.dart';
+import 'package:rly_network_flutter_sdk/key_storage_config.dart';
 
 import 'key_manager.dart';
 
@@ -18,14 +19,18 @@ class AccountsUtil {
     return _instance;
   }
 
-  Future<Wallet> createAccount({bool overwrite = false}) async {
+  Future<Wallet> createAccount(
+      {bool overwrite = false, KeyStorageConfig? storageOptions}) async {
     final existingWallet = await getWallet();
     if (existingWallet != null && !overwrite) {
       throw 'Account already exists';
     }
 
+    final storageConfig = storageOptions ??
+        KeyStorageConfig(rejectOnCloudSaveFailure: true, saveToCloud: true);
+
     final mnemonic = await _keyManager.generateMnemonic();
-    await _keyManager.saveMnemonic(mnemonic);
+    await _keyManager.saveMnemonic(mnemonic, options: storageConfig);
     final newWallet = await _makeWalletFromMnemonic(mnemonic);
 
     _cachedWallet = newWallet;

--- a/lib/account.dart
+++ b/lib/account.dart
@@ -30,7 +30,7 @@ class AccountsUtil {
         KeyStorageConfig(rejectOnCloudSaveFailure: true, saveToCloud: true);
 
     final mnemonic = await _keyManager.generateMnemonic();
-    await _keyManager.saveMnemonic(mnemonic, options: storageConfig);
+    await _keyManager.saveMnemonic(mnemonic, storageOptions: storageConfig);
     final newWallet = await _makeWalletFromMnemonic(mnemonic);
 
     _cachedWallet = newWallet;

--- a/lib/key_manager.dart
+++ b/lib/key_manager.dart
@@ -36,14 +36,12 @@ class KeyManager {
   }
 
   Future<void> saveMnemonic(String mnemonic,
-      {KeyStorageConfig? options}) async {
-    if (options == null || !options.saveToCloud) {
-      await methodChannel.invokeMethod("saveMnemonic", {
-        "mnemonic": mnemonic,
-        "useBlockStore": true,
-        "forceBlockStore": true,
-      });
-    }
+      {required KeyStorageConfig storageOptions}) async {
+    await methodChannel.invokeMethod("saveMnemonic", {
+      "mnemonic": mnemonic,
+      "useBlockStore": storageOptions.saveToCloud,
+      "forceBlockStore": storageOptions.rejectOnCloudSaveFailure,
+    });
   }
 
   Uint8List _intListToUint8List(List<Object?> intList) {

--- a/lib/key_manager.dart
+++ b/lib/key_manager.dart
@@ -39,8 +39,8 @@ class KeyManager {
       {required KeyStorageConfig storageOptions}) async {
     await methodChannel.invokeMethod("saveMnemonic", {
       "mnemonic": mnemonic,
-      "useBlockStore": storageOptions.saveToCloud,
-      "forceBlockStore": storageOptions.rejectOnCloudSaveFailure,
+      "saveToCloud": storageOptions.saveToCloud,
+      "rejectOnCloudSaveFailure": storageOptions.rejectOnCloudSaveFailure,
     });
   }
 


### PR DESCRIPTION
- Expose ability to configure cloud storage when creating wallet.
- Bring android Mnemonic storage inline with our trusted kotlin source.
- Native code honors the cloud sync flags passed in from Dart layer.

We provide a default of turning on cloud sync, since that's what we hear most developers want.
This opens up the ability for more sophisticated developers to build their own user UX to configure cloud sync though.
