### PR TITLE
Rename main wallet interfaces for better consistency with web3 terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ final account = await WalletManager.getInstance().createWallet(
     storageOptions: KeyStorageConfig(saveToCloud: false, rejectOnCloudSaveFailure: false)
 );
 
-// get current user account address
-final address = await WalletManager.getInstance().getAccountAddress();
+// get address of current EOA wallet
+final address = await WalletManager.getInstance().getPublicAddress();
 
-// delete account
-
-await WalletManager.getInstance().permanentlyDeleteAccount();
+// Delete EOA wallet. Be careful calling this, it can not be undone.
+await WalletManager.getInstance().permanentlyDeleteWallet();
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,20 @@ import 'package:rly_network_flutter_sdk/account.dart';
 
 
 //create an account
-
 // By default this will configure the keys for secure cloud syncing
-final account = await AccountsUtil.getInstance().createAccount();
+final account = await WalletManager.getInstance().createAccount();
 
 //Want to configure whether keys are synced to the cloud, you can pass in storage options
-final account = await AccountsUtil.getInstance().createAccount(
+final account = await WalletManager.getInstance().createAccount(
     storageOptions: KeyStorageConfig(saveToCloud: false, rejectOnCloudSaveFailure: false)
 );
 
 // get current user account address
-final address = await AccountsUtil.getInstance().getAccountAddress();
+final address = await WalletManager.getInstance().getAccountAddress();
 
 // delete account
 
-await AccountsUtil.getInstance().permanentlyDeleteAccount();
+await WalletManager.getInstance().permanentlyDeleteAccount();
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ import 'package:rly_network_flutter_sdk/account.dart';
 
 //create an account
 // By default this will configure the keys for secure cloud syncing
-final account = await WalletManager.getInstance().createAccount();
+final account = await WalletManager.getInstance().createWallet();
 
 //Want to configure whether keys are synced to the cloud, you can pass in storage options
-final account = await WalletManager.getInstance().createAccount(
+final account = await WalletManager.getInstance().createWallet(
     storageOptions: KeyStorageConfig(saveToCloud: false, rejectOnCloudSaveFailure: false)
 );
 

--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:rly_network_flutter_sdk/account.dart';
+import 'package:rly_network_flutter_sdk/wallet_manager.dart';
 import 'package:rly_network_flutter_sdk/gsn/utils.dart';
 import 'package:rly_network_flutter_sdk/network.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -87,12 +87,12 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
   }
 
   void deleteAccount() async {
-    await AccountsUtil.getInstance().permanentlyDeleteAccount();
+    await WalletManager.getInstance().permanentlyDeleteAccount();
     widget.onAccountDeleted();
   }
 
   void revealMnemonic() async {
-    String? value = await AccountsUtil.getInstance().getAccountPhrase();
+    String? value = await WalletManager.getInstance().getAccountPhrase();
     if (value == null || value.isEmpty) {
       throw 'Something went wrong, no Mnemonic when there should be one';
     }

--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -87,7 +87,7 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
   }
 
   void deleteAccount() async {
-    await WalletManager.getInstance().permanentlyDeleteAccount();
+    await WalletManager.getInstance().permanentlyDeleteWallet();
     widget.onAccountDeleted();
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:rly_network_flutter_sdk/wallet.dart';
+import 'package:rly_network_flutter_sdk/wallet_manager.dart';
 
 import 'account_overview_screen.dart';
 import 'generate_account_screen.dart';
 import 'loading_screen.dart';
-import 'package:rly_network_flutter_sdk/account.dart';
 
 class App extends StatefulWidget {
   const App({super.key});
@@ -24,7 +24,7 @@ class AppState extends State<App> {
   }
 
   Future<void> _readAccount() async {
-    final account = await AccountsUtil.getInstance().getWallet();
+    final account = await WalletManager.getInstance().getWallet();
     setState(() {
       _accountLoaded = true;
       if (account != null) {
@@ -40,8 +40,7 @@ class AppState extends State<App> {
   }
 
   Future<void> _createRlyAccount() async {
-    AccountsUtil accountsUtil = AccountsUtil.getInstance();
-    final rlyAct = await accountsUtil.createAccount();
+    final rlyAct = await WalletManager.getInstance().createAccount();
     setState(() {
       _rlyAccount = rlyAct;
     });

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,7 +40,7 @@ class AppState extends State<App> {
   }
 
   Future<void> _createRlyAccount() async {
-    final rlyAct = await WalletManager.getInstance().createAccount();
+    final rlyAct = await WalletManager.getInstance().createWallet();
     setState(() {
       _rlyAccount = rlyAct;
     });

--- a/lib/networks/evm_networks.dart
+++ b/lib/networks/evm_networks.dart
@@ -3,7 +3,7 @@ import 'package:rly_network_flutter_sdk/gsn/utils.dart';
 import 'package:rly_network_flutter_sdk/network.dart';
 import 'package:web3dart/web3dart.dart';
 
-import '../account.dart';
+import '../wallet_manager.dart';
 import '../contracts/erc20.dart';
 import '../error.dart';
 import '../gsn/EIP712/meta_transactions.dart';
@@ -18,7 +18,7 @@ class NetworkImpl extends Network {
 
   @override
   Future<String> claimRly() async {
-    final account = await AccountsUtil.getInstance().getWallet();
+    final account = await WalletManager.getInstance().getWallet();
 
     if (account == null) {
       throw "account does not exist";
@@ -41,7 +41,7 @@ class NetworkImpl extends Network {
   @override
   Future<double> getBalance(
       {PrefixedHexString? tokenAddress, bool humanReadable = false}) async {
-    final account = await AccountsUtil.getInstance().getWallet();
+    final account = await WalletManager.getInstance().getWallet();
     if (account == null) {
       throw missingWalletError;
     }
@@ -65,7 +65,7 @@ class NetworkImpl extends Network {
 
   @override
   Future<String> relay(GsnTransactionDetails tx) async {
-    final account = await AccountsUtil.getInstance().getWallet();
+    final account = await WalletManager.getInstance().getWallet();
 
     if (account == null) {
       throw "account does not exist";
@@ -83,7 +83,7 @@ class NetworkImpl extends Network {
   Future<String> transfer(
       String destinationAddress, double amount, MetaTxMethod metaTxMethod,
       {PrefixedHexString? tokenAddress}) async {
-    final account = await AccountsUtil.getInstance().getWallet();
+    final account = await WalletManager.getInstance().getWallet();
 
     if (account == null) {
       throw "account does not exist";
@@ -135,7 +135,7 @@ class NetworkImpl extends Network {
   Future<String> simpleTransfer(String destinationAddress, double amount,
       {String? tokenAddress, MetaTxMethod? metaTxMethod}) async {
     Web3Client client = getEthClient(network.gsn.rpcUrl);
-    final account = await AccountsUtil.getInstance().getWallet();
+    final account = await WalletManager.getInstance().getWallet();
 
     if (account == null) {
       throw missingWalletError;

--- a/lib/wallet_manager.dart
+++ b/lib/wallet_manager.dart
@@ -54,7 +54,7 @@ class WalletManager {
     return wallet;
   }
 
-  Future<String?> getAccountAddress() async {
+  Future<String?> getPublicAddress() async {
     final wallet = await getWallet();
     if (wallet == null) {
       return null;
@@ -62,7 +62,7 @@ class WalletManager {
     return wallet.address.hex;
   }
 
-  Future<void> permanentlyDeleteAccount() async {
+  Future<void> permanentlyDeleteWallet() async {
     await _keyManager.deleteMnemonic();
     _cachedWallet = null;
   }

--- a/lib/wallet_manager.dart
+++ b/lib/wallet_manager.dart
@@ -7,15 +7,15 @@ import 'key_manager.dart';
 
 import 'wallet.dart';
 
-class AccountsUtil {
+class WalletManager {
   static Wallet? _cachedWallet;
   final KeyManager _keyManager;
 
-  AccountsUtil(this._keyManager);
+  WalletManager(this._keyManager);
 
-  static final AccountsUtil _instance = AccountsUtil(KeyManager());
+  static final WalletManager _instance = WalletManager(KeyManager());
 
-  factory AccountsUtil.getInstance() {
+  factory WalletManager.getInstance() {
     return _instance;
   }
 

--- a/lib/wallet_manager.dart
+++ b/lib/wallet_manager.dart
@@ -75,37 +75,6 @@ class WalletManager {
     }
   }
 
-  Future<String> signMessage(String message) async {
-    final wallet = await getWallet();
-
-    if (wallet == null) {
-      throw 'No account';
-    }
-    throw UnimplementedError();
-    // return wallet.signMessage(message);
-  }
-
-  Future<String> signTransaction() async {
-    final wallet = await getWallet();
-    if (wallet == null) {
-      throw 'No account';
-    }
-    throw UnimplementedError();
-    // return wallet.signTransaction(tx);
-  }
-
-  Future<String> signHash(String hash) async {
-    final wallet = await getWallet();
-    if (wallet == null) {
-      throw 'No account';
-    }
-    throw UnimplementedError();
-
-    // final signingKey = utils.SigningKey(wallet.privateKey);
-    //
-    // return utils.joinSignature(signingKey.signDigest(hash));
-  }
-
   Future<Wallet> _makeWalletFromMnemonic(String mnemonic) async {
     Uint8List privateKey =
         await _keyManager.getPrivateKeyFromMnemonic(mnemonic);

--- a/lib/wallet_manager.dart
+++ b/lib/wallet_manager.dart
@@ -19,7 +19,7 @@ class WalletManager {
     return _instance;
   }
 
-  Future<Wallet> createAccount(
+  Future<Wallet> createWallet(
       {bool overwrite = false, KeyStorageConfig? storageOptions}) async {
     final existingWallet = await getWallet();
     if (existingWallet != null && !overwrite) {


### PR DESCRIPTION
**The bad news is that this is a breaking change.** Luckily we don't have many/any external devs we need to worry about that we aren't in direct contact with. Also haven't actually published a package yet. 

- Rename top level account stuff to capture wallet management concept.
- Rename all wallet CRUD method(s) for better clarity.
- Remove misplaced signing wrappers that didn't work anyway
