### PR TITLE
Prep setting for publishing to pub.dev

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,1 @@
+example/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: rly_network_flutter_sdk
 description: RLY Network Flutter SDK
 version: 0.0.1
-homepage:
+homepage: https://www.rallyprotocol.com
+repository: https://github.com/rally-dfs/flutter-sdk
 
 environment:
   sdk: ">=3.0.5 <4.0.0"


### PR DESCRIPTION
- Provide links for pub.dev listing page pointing to homepage + GH repo.
- Don't include example app in pub.dev package
