### PR TITLE
Fix type error fetching balance in example app

### DIFF
--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -29,7 +29,7 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
       loading = true;
     });
 
-    double bal = await rlyNetwork.getBalance();
+    double bal = await rlyNetwork.getDisplayBalance();
     setState(() {
       balance = bal;
       loading = false;


### PR DESCRIPTION
Never handled the underlying API change to human readable balance vs raw
big int balance. This addresses that by being more explicit that we want
the display balance in the example app use case.
