### PR TITLE
Add new SDK method to check whether existing wallet is backed up to cloud

### DIFF
--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/FlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/FlutterSdkPlugin.kt
@@ -52,6 +52,9 @@ class FlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
         "getMnemonic" -> {
           getMnemonic(result)
         }
+        "mnemonicBackedUpToCloud" -> {
+          isBackedUpToCloud(result)
+        }
         "deleteMnemonic" -> {
           deleteMnemonic(result)
         }
@@ -68,8 +71,14 @@ class FlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
   }
 
   private fun getMnemonic(result: Result) {
-    mnemonicHelper.read(MNEMONIC_STORAGE_KEY) { mnemonic: String? ->
+    mnemonicHelper.read(MNEMONIC_STORAGE_KEY) { mnemonic: String?, fromBlockstore ->
       result.success(mnemonic)
+    }
+  }
+
+  private fun isBackedUpToCloud(result: Result) {
+    mnemonicHelper.read(MNEMONIC_STORAGE_KEY) { mnemonic, fromBlockstore ->
+      result.success(mnemonic != null && fromBlockstore);
     }
   }
 

--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
@@ -61,7 +61,7 @@ class MnemonicStorageHelper(context: Context) {
         editor.commit()
     }
 
-    fun read(key: String, onSuccess: (mnemonic: String?) -> Unit) {
+    fun read(key: String, onSuccess: (mnemonic: String?, fromBlockstore: Boolean) -> Unit) {
 
         val retrieveRequest = RetrieveBytesRequest.Builder()
             .setKeys(listOf(key))
@@ -73,19 +73,19 @@ class MnemonicStorageHelper(context: Context) {
 
                 if (blockstoreDataMap.isEmpty()) {
                     val mnemonic = readFromSharedPref(key)
-                    onSuccess(mnemonic)
+                    onSuccess(mnemonic, false)
                 } else {
                     val mnemonic = blockstoreDataMap[key]
                     if (mnemonic !== null) {
-                        onSuccess(mnemonic.bytes.toString(Charsets.UTF_8))
+                        onSuccess(mnemonic.bytes.toString(Charsets.UTF_8), true)
                     } else {
-                        onSuccess(null)
+                        onSuccess(null, true)
                     }
                 }
             }
             .addOnFailureListener {
                 val mnemonic = readFromSharedPref(key)
-                onSuccess(mnemonic)
+                onSuccess(mnemonic, false)
             }
     }
 

--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -25,15 +25,17 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
   String transferAddress = '0x5205BcC1852c4b626099aa7A2AFf36Ac3e9dE83b';
   String? mnemonic;
 
-  void fetchBalance() async {
-    setState(() {
-      loading = true;
-    });
-
+  void getWalletBackupState() async {
     bool backedUp = await WalletManager.getInstance().walletBackedUpToCloud();
 
     setState(() {
       backedUpToCloud = backedUp;
+    });
+  }
+
+  void fetchBalance() async {
+    setState(() {
+      loading = true;
     });
 
     double bal = await rlyNetwork.getDisplayBalance();
@@ -46,6 +48,7 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
   @override
   void initState() {
     super.initState();
+    getWalletBackupState();
     fetchBalance();
     // RlyNetwork.setApiKey(
     //     "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOjEzNX0.wqnX-E-KRvzqLgIBAw6RV-BT1puWuZgVdAsqxoU1nL2z8hxTkT4OlH7G6Okv9l3qRMLxMbkORg14XTko-gJW1A");

--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -20,6 +20,7 @@ class AccountOverviewScreen extends StatefulWidget {
 class AccountOverviewScreenState extends State<AccountOverviewScreen> {
   bool loading = false;
   double? balance;
+  bool? backedUpToCloud;
   String transferBalance = '1';
   String transferAddress = '0x5205BcC1852c4b626099aa7A2AFf36Ac3e9dE83b';
   String? mnemonic;
@@ -27,6 +28,12 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
   void fetchBalance() async {
     setState(() {
       loading = true;
+    });
+
+    bool backedUp = await WalletManager.getInstance().walletBackedUpToCloud();
+
+    setState(() {
+      backedUpToCloud = backedUp;
     });
 
     double bal = await rlyNetwork.getDisplayBalance();
@@ -144,6 +151,10 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
                               style: const TextStyle(
                                 fontWeight: FontWeight.bold,
                               )),
+                          const SizedBox(height: 12),
+                          Text(
+                              'Backed up to cloud: ${backedUpToCloud ?? 'Loading...'}'),
+                          const SizedBox(height: 24),
                           const Text('Your Current Balance Is'),
                           Text(balance?.toString() ?? 'Loading...'),
                           const SizedBox(height: 12),

--- a/ios/Classes/FlutterSdkPlugin.swift
+++ b/ios/Classes/FlutterSdkPlugin.swift
@@ -27,9 +27,10 @@ public class FlutterSdkPlugin: NSObject, FlutterPlugin {
         }
         case "getMnemonic":
           result(RlyNetworkMobileSdk().getMnemonic())
+        case "mnemonicBackedUpToCloud":
+          result(RlyNetworkMobileSdk().mnemonicBackedUpToCloud())
         case "deleteMnemonic":
           result(RlyNetworkMobileSdk().deleteMnemonic())
-
         case "saveMnemonic":
           if let arguments = call.arguments as? [String: Any],
             let mnemonicToSave = arguments["mnemonic"] as? String,

--- a/ios/Classes/KeyChainHelper.swift
+++ b/ios/Classes/KeyChainHelper.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 final class KeychainHelper {
-    
+
     static let standard = KeychainHelper()
     private init() {}
-    
+
     func save(
       _ data: Data,
       service: String,
@@ -36,30 +36,45 @@ final class KeychainHelper {
             SecItemUpdate(query, attributesToUpdate)
         }
     }
-    
+
+    func readAttributes(service: String, account: String) -> [String: Any]? {
+        let query = [
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecClass: kSecClassGenericPassword,
+            kSecReturnAttributes: true
+        ] as CFDictionary
+
+        var result: AnyObject?
+        SecItemCopyMatching(query, &result)
+
+        return (result as? [String: Any])
+    }
+
+
     func read(service: String, account: String) -> Data? {
-        
+
         let query = [
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
             kSecReturnData: true
         ] as CFDictionary
-        
+
         var result: AnyObject?
         SecItemCopyMatching(query, &result)
-        
+
         return (result as? Data)
     }
-    
+
     func delete(service: String, account: String) {
-        
+
         let query = [
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
             ] as CFDictionary
-        
+
         // Delete item from keychain
         SecItemDelete(query)
     }

--- a/lib/key_manager.dart
+++ b/lib/key_manager.dart
@@ -26,6 +26,16 @@ class KeyManager {
     return mnemonic;
   }
 
+  Future<bool> walletBackedUpToCloud() async {
+    bool? backedUpToCloud =
+        await methodChannel.invokeMethod<bool>("mnemonicBackedUpToCloud");
+    if (backedUpToCloud == null) {
+      throw Exception(
+          "Unable to get wallet backup status, something went wrong at native code layer");
+    }
+    return backedUpToCloud;
+  }
+
   Future<Uint8List> getPrivateKeyFromMnemonic(String mnemonic) async {
     List<Object?>? pvtKey = await methodChannel
         .invokeMethod<List<Object?>>("getPrivateKeyFromMnemonic", {

--- a/lib/wallet_manager.dart
+++ b/lib/wallet_manager.dart
@@ -33,7 +33,9 @@ class WalletManager {
   }
 
   /// Returns the cloud backup status of the existing wallet.
-  /// Returns false if there is currently no wallet.
+  /// Returns false if there is currently no wallet. This method should not be used as a check for wallet existence
+  /// as it will return false if there is no wallet or if the wallet does exist but is not backed up to cloud.
+  ///
   /// If a wallet already exists the reponse will be true or false depending on whether the wallet is backed up to cloud or not.
   /// TRUE response means wallet is backed up to cloud, FALSE means wallet is not backed up to cloud.
   Future<bool> walletBackedUpToCloud() async {

--- a/lib/wallet_manager.dart
+++ b/lib/wallet_manager.dart
@@ -32,6 +32,14 @@ class WalletManager {
     return newWallet;
   }
 
+  /// Returns the cloud backup status of the existing wallet.
+  /// Returns false if there is currently no wallet.
+  /// If a wallet already exists the reponse will be true or false depending on whether the wallet is backed up to cloud or not.
+  /// TRUE response means wallet is backed up to cloud, FALSE means wallet is not backed up to cloud.
+  Future<bool> walletBackedUpToCloud() async {
+    return await _keyManager.walletBackedUpToCloud();
+  }
+
   Future<Wallet?> getWallet() async {
     if (_cachedWallet != null) {
       return _cachedWallet!;


### PR DESCRIPTION
Supports the common use case where developers did not persistently store the flags they used to create a wallet. 

Adds the method `walletBackedUpToCloud` to `WalletManager`. 

--- 

Code on iOS could use a bit of cleanup to DRY us some of the query logic, but this version is currently working, and DRYing up the query logic introduces a good amount of type complexity, so I'm curious on whether it's worth it. 

I also started adding code comments to our publicly facing SDK methods, for improved auto generated pub.dev docs. 