### PR TITLE
Fix balance issue that breaks claimRly public method

### DIFF
--- a/lib/src/networks/evm_networks.dart
+++ b/lib/src/networks/evm_networks.dart
@@ -25,10 +25,10 @@ class NetworkImpl extends Network {
       throw "account does not exist";
     }
 
-    final existingBalance = await getBalance();
+    final existingBalance = await getExactBalance();
     // final existingBalance = 0;
 
-    if (existingBalance > 0) {
+    if (existingBalance > BigInt.zero) {
       throw priorDustingError;
     }
 


### PR DESCRIPTION
This must have been missed when we moved to the new distinction between
human readable and non human readable balances. The dynamic value was
causing the claim method to throw a type mismatch when comparing to 0.
