### PR TITLE
Allow recovery from bad backup and restore process

### DIFF
--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
@@ -8,6 +8,8 @@ import androidx.security.crypto.MasterKey
 import androidx.security.crypto.MasterKey.Builder
 import com.google.android.gms.auth.blockstore.*
 
+private const val ENCRYPTED_PREFERENCE_FILENAME = "encrypted_mnemonic"
+
 class MnemonicStorageHelper(context: Context) {
     private val sharedPreferences: SharedPreferences
     private val blockstoreClient: BlockstoreClient
@@ -22,7 +24,7 @@ class MnemonicStorageHelper(context: Context) {
         try {
             attemptedSharedPreferences = EncryptedSharedPreferences.create(
                 context,
-                "encrypted_mnemonic",
+                ENCRYPTED_PREFERENCE_FILENAME,
                 masterKey,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
@@ -32,11 +34,11 @@ class MnemonicStorageHelper(context: Context) {
             // the master key being invalidated. In this case, we need to clear the shared preferences
             // and recreate them. The user will lose their mnemonic, but this is the only way to
             // recover from this situation.
-            context.getSharedPreferences("encrypted_mnemonic", Context.MODE_PRIVATE).edit().clear().apply()
+            context.getSharedPreferences(ENCRYPTED_PREFERENCE_FILENAME, Context.MODE_PRIVATE).edit().clear().apply()
            
             attemptedSharedPreferences = EncryptedSharedPreferences.create(
                 context,
-                "encrypted_mnemonic",
+                ENCRYPTED_PREFERENCE_FILENAME,
                 masterKey,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM

--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
@@ -11,19 +11,26 @@ import com.google.android.gms.auth.blockstore.*
 private const val ENCRYPTED_PREFERENCE_FILENAME = "encrypted_mnemonic"
 
 class MnemonicStorageHelper(context: Context) {
-    private val sharedPreferences: SharedPreferences
     private val blockstoreClient: BlockstoreClient
-    private var isEndToEndEncryptionAvailable: Boolean = false;
+    private var isEndToEndEncryptionAvailable: Boolean = false
+    private val localContext: Context = context
 
     init {
-        val masterKey: MasterKey = Builder(context)
+        blockstoreClient = Blockstore.getClient(context)
+        blockstoreClient.isEndToEndEncryptionAvailable.addOnSuccessListener { isE2EEAvailable ->
+            isEndToEndEncryptionAvailable = isE2EEAvailable
+        }
+    }
+    
+    fun getSharedPreferences(): SharedPreferences {
+        val masterKey: MasterKey = Builder(localContext)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
 
         var attemptedSharedPreferences: SharedPreferences
         try {
             attemptedSharedPreferences = EncryptedSharedPreferences.create(
-                context,
+                localContext,
                 ENCRYPTED_PREFERENCE_FILENAME,
                 masterKey,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
@@ -34,23 +41,17 @@ class MnemonicStorageHelper(context: Context) {
             // the master key being invalidated. In this case, we need to clear the shared preferences
             // and recreate them. The user will lose their mnemonic, but this is the only way to
             // recover from this situation.
-            context.getSharedPreferences(ENCRYPTED_PREFERENCE_FILENAME, Context.MODE_PRIVATE).edit().clear().apply()
+            localContext.getSharedPreferences(ENCRYPTED_PREFERENCE_FILENAME, Context.MODE_PRIVATE).edit().clear().apply()
            
             attemptedSharedPreferences = EncryptedSharedPreferences.create(
-                context,
+                localContext,
                 ENCRYPTED_PREFERENCE_FILENAME,
                 masterKey,
                 EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
             )
         }
-        
-        sharedPreferences = attemptedSharedPreferences
-
-        blockstoreClient = Blockstore.getClient(context)
-        blockstoreClient.isEndToEndEncryptionAvailable.addOnSuccessListener { isE2EEAvailable ->
-            isEndToEndEncryptionAvailable = isE2EEAvailable
-        }
+        return attemptedSharedPreferences
     }
 
     fun save(key: String, mnemonic: String, useBlockStore: Boolean, forceBlockStore: Boolean, onSuccess: () -> Unit, onFailure: (message: String) -> Unit) {
@@ -83,7 +84,7 @@ class MnemonicStorageHelper(context: Context) {
     }
 
     private fun saveToSharedPref(key: String, mnemonic: String) {
-        val editor = sharedPreferences.edit()
+        val editor = getSharedPreferences().edit()
         editor.putString(key, mnemonic)
         editor.commit()
     }
@@ -117,7 +118,7 @@ class MnemonicStorageHelper(context: Context) {
     }
 
     private fun readFromSharedPref(key: String): String? {
-        return sharedPreferences.getString(key, null)
+        return getSharedPreferences().getString(key, null)
     }
 
     fun delete(key: String) {
@@ -127,7 +128,7 @@ class MnemonicStorageHelper(context: Context) {
 
         blockstoreClient.deleteBytes(retrieveRequest)
 
-        val editor = sharedPreferences.edit()
+        val editor = getSharedPreferences().edit()
         editor.remove(key)
         editor.commit()
     }


### PR DESCRIPTION
When users do not have cloud backup via `Blockstore` they fall back to `EncryptedSharedPreferences`; Encrypted preferences have an issue with being backed up and restored from device to device backups. The encryption key is intentionally not moved along with the shared preferences. When the restore occurs the SDK attempts to decrypt the restored shared preference without the decryption key and throws an error.

This PR solves the underlying unreadable preference, and also updated the shared preference object to be created on use instead of `MnemonicStorageHelper` init
