### PR TITLE
Update mumbai network config to actually point at Amoy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,17 @@
 ### 0.3.2
 
 * Addressed a bug that caused SDK to hang when trying to interact with wallets on Android following device backup and restore.
+
+## 0.4.0
+
+If you are only using wallet management features, there are no changes in this release
+
+**This release is not backwards compatible with previous versions if you are using any transaction features**
+
+This release migrates away from Mumbai and over to Amoy. This is required as Mumbai is deprecated and will stop working around 4/13.
+
+To migrate you will need to follow the following steps:
+1. Update your SDK to 0.4.0
+2. Rename references from `rlyMumbaiNetwork` to `rlyAmoyNetwork`
+3. Get your new Amoy API key from https://app.rallyprotocol.com
+4. Update your config to set the new API key

--- a/README.md
+++ b/README.md
@@ -30,25 +30,25 @@ await WalletManager.getInstance().permanentlyDeleteWallet();
 ```dart
 import 'package:rly_network_flutter_sdk/rly_network_flutter_sdk.dart';
 
-//get mumbai config for rally protocol sdk
+//get polygon testnet (amoy) config for rally protocol sdk
 
-final mumbai = rlyMumbaiNetwork;
+final amoy = rlyAmoyNetwork;
 
 // add your API Key
 
-mumbai.setApiKey(env.API_KEY);
+amoy.setApiKey(env.API_KEY);
 
 // this is simple method for claiming 10 test ERC20 tokens for testing
 
-await mumbai.claimRly();
+await amoy.claimRly();
 
 // get balance of any ERC20 token
 
-await mumbai.getBalance(tokenAddress);
+await amoy.getBalance(tokenAddress);
 
 // transfer any ERC20 token, to transfer gaslessly token contract must support permit() or executeMetaTransaction() (most ERC20s on polygon support this)
 
-await mumbai.transfer(transferAddress, double.parse(1), MetaTxMethod.ExecuteMetaTransaction, {tokenAddress});
+await amoy.transfer(transferAddress, double.parse(1), MetaTxMethod.ExecuteMetaTransaction, {tokenAddress});
 
 
 
@@ -66,7 +66,7 @@ final gsnTx = GsnTransactionDetails(
     maxPriorityFeePerGas: maxPriorityFeePerGas.toString(),
     );
 
-await mumbai.relay(gsnTx)
+await amoy.relay(gsnTx)
 
 
 ```

--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -162,7 +162,7 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
                           FullWidthButton(
                             onPressed: () async {
                               await launchUrl(Uri.parse(
-                                  'https://mumbai.polygonscan.com/address/${widget.walletAddress}'));
+                                  'https://www.oklink.com/amoy/address/${widget.walletAddress}'));
                             },
                             child: const Text('View on Polygon'),
                           ),

--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -48,10 +48,8 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
     super.initState();
     getWalletBackupState();
     fetchBalance();
-    // RlyNetwork.setApiKey(
-    //     "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOjEzNX0.wqnX-E-KRvzqLgIBAw6RV-BT1puWuZgVdAsqxoU1nL2z8hxTkT4OlH7G6Okv9l3qRMLxMbkORg14XTko-gJW1A");
     rlyNetwork.setApiKey(
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOjkzfQ.PgErzRN88Sz07OKp9aj0cUxCap_chaqTsDzgkaIc7NMC_WSPeL4HUlmSb_spHe5N_Gk7EYsF-1QFXg-rIp7ETA");
+        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOjUxOH0.m8M8gE94u3_wvDV4aQnImTufK6FxNiHoJCUokQbzY6vqeHnFDohnxD2N_HRMhEf_q15WWtM4jPkHJDmB63h1ow");
   }
 
   void claimRlyTokens() async {

--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:rly_network_flutter_sdk/rly_network_flutter_sdk.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-final rlyNetwork = rlyMumbaiNetwork;
+final rlyNetwork = rlyAmoyNetwork;
 
 class AccountOverviewScreen extends StatefulWidget {
   final String walletAddress;

--- a/lib/src/network.dart
+++ b/lib/src/network.dart
@@ -2,7 +2,7 @@ import './networks/evm_networks.dart';
 
 import 'gsn/meta_tx_method.dart';
 import 'gsn/utils.dart';
-import 'network_config/network_config_mumbai.dart';
+import 'network_config/network_config_amoy.dart';
 import 'network_config/network_config_local.dart';
 import 'network_config/network_config_polygon.dart';
 
@@ -25,6 +25,6 @@ abstract class Network {
   void setApiKey(String apiKey);
 }
 
-final Network rlyMumbaiNetwork = NetworkImpl(mumbaiNetworkConfig);
+final Network rlyAmoyNetwork = NetworkImpl(amoyNetworkConfig);
 final Network rlyLocalNetwork = NetworkImpl(localNetworkConfig);
 final Network rlyPolygonNetwork = NetworkImpl(polygonNetworkConfig);

--- a/lib/src/network_config/network_config_amoy.dart
+++ b/lib/src/network_config/network_config_amoy.dart
@@ -1,6 +1,6 @@
 import './network_config.dart';
 
-final NetworkConfig mumbaiNetworkConfig = NetworkConfig(
+final NetworkConfig amoyNetworkConfig = NetworkConfig(
   contracts: Contracts(
     rlyERC20: '0x846d8a5fb8a003b431b67115f809a9b9fffe5012',
     tokenFaucet: '0xb8c8274f775474f4f2549edcc4db45cbad936fac',

--- a/lib/src/network_config/network_config_mumbai.dart
+++ b/lib/src/network_config/network_config_mumbai.dart
@@ -13,7 +13,7 @@ final NetworkConfig mumbaiNetworkConfig = NetworkConfig(
     relayUrl: 'https://api.rallyprotocol.com',
     rpcUrl:
         'https://polygon-amoy.g.alchemy.com/v2/-dYNjZXvre3GC9kYtwDzzX4N8tcgomU4',
-    chainId: '80001',
+    chainId: '80002',
     maxAcceptanceBudget: '285252',
     domainSeparatorName: 'GSN Relayed Transaction',
     gtxDataNonZero: 16,

--- a/lib/src/network_config/network_config_mumbai.dart
+++ b/lib/src/network_config/network_config_mumbai.dart
@@ -2,17 +2,17 @@ import './network_config.dart';
 
 final NetworkConfig mumbaiNetworkConfig = NetworkConfig(
   contracts: Contracts(
-    rlyERC20: '0x1C7312Cb60b40cF586e796FEdD60Cf243286c9E9',
-    tokenFaucet: '0xe7C3BD692C77Ec0C0bde523455B9D142c49720fF',
+    rlyERC20: '0x846d8a5fb8a003b431b67115f809a9b9fffe5012',
+    tokenFaucet: '0xb8c8274f775474f4f2549edcc4db45cbad936fac',
   ),
   gsn: GSNConfig(
-    paymasterAddress: '0x8b3a505413Ca3B0A17F077e507aF8E3b3ad4Ce4d',
-    forwarderAddress: '0xB2b5841DBeF766d4b521221732F9B618fCf34A87',
-    relayHubAddress: '0x3232f21A6E08312654270c78A773f00dd61d60f5',
+    paymasterAddress: '0xb570b57b821670707fF4E38Ea53fcb67192278F8',
+    forwarderAddress: '0x0ae8FC9867CB4a124d7114B8bd15C4c78C4D40E5',
+    relayHubAddress: '0xe213A20A9E6CBAfd8456f9669D8a0b9e41Cb2751',
     relayWorkerAddress: '0xb9950b71ec94cbb274aeb1be98e697678077a17f',
     relayUrl: 'https://api.rallyprotocol.com',
     rpcUrl:
-        'https://polygon-mumbai.g.alchemy.com/v2/-dYNjZXvre3GC9kYtwDzzX4N8tcgomU4',
+        'https://polygon-amoy.g.alchemy.com/v2/-dYNjZXvre3GC9kYtwDzzX4N8tcgomU4',
     chainId: '80001',
     maxAcceptanceBudget: '285252',
     domainSeparatorName: 'GSN Relayed Transaction',


### PR DESCRIPTION
This is not a backwards compatible change. After some thought, and discussion, it was decided that you can't simply call something mumbai but point it at Amoy, because Amoy breaks too many things. None of the contract addresses are the same, so devs will need to make a conscious migration to Amoy. 