### PR TITLE
Balance check in simple transfer needs simple (aka display) balance

### DIFF
--- a/lib/src/networks/evm_networks.dart
+++ b/lib/src/networks/evm_networks.dart
@@ -111,7 +111,7 @@ class NetworkImpl extends Network {
 
     tokenAddress = tokenAddress ?? network.contracts.rlyERC20;
 
-    final sourceBalance = await getBalance(tokenAddress: tokenAddress);
+    final sourceBalance = await getDisplayBalance(tokenAddress: tokenAddress);
 
     final sourceFinalBalance = sourceBalance - amount;
 


### PR DESCRIPTION
If you attempt to get the exact balance you are then attempting to
compare an int to a bigint value and you have runtime issues
