### PR TITLE
Fix bug preventing tranfers of more than 9.9 of a token

### DIFF
--- a/lib/src/gsn/EIP712/permit_transaction.dart
+++ b/lib/src/gsn/EIP712/permit_transaction.dart
@@ -68,8 +68,8 @@ Map<String, dynamic> getTypedPermitTransaction(Permit permit) {
   final message = {
     'owner': permit.owner,
     'spender': permit.spender,
-    'value': permit.value.toInt(),
-    'nonce': permit.nonce.toInt(),
+    'value': permit.value.toString(),
+    'nonce': permit.nonce.toString(),
     'deadline': permit.deadline.toInt(),
   };
 


### PR DESCRIPTION
Never take a BigInt value in crypto and turn it into an int, bad things
will happen.

Went on quite the expedition to find this one, but ultimately it was a
signature mismatch error causing the transactions to fail. The mismatch
was caused by proper handling of BigInt in 1 part, with inproper
conversion of BigInt to Int in another part of code, which for values
over 9.9 in decimal form was overflowing the int.
