### PR TITLE
Extract some token helpers for better 3rd party dev ergonomics

### DIFF
--- a/lib/rly_network_flutter_sdk.dart
+++ b/lib/rly_network_flutter_sdk.dart
@@ -3,3 +3,4 @@ export 'src/network.dart';
 export 'src/wallet_manager.dart';
 export 'src/wallet.dart';
 export 'src/gsn/meta_tx_method.dart';
+export 'src/token_helpers.dart';

--- a/lib/src/networks/evm_networks.dart
+++ b/lib/src/networks/evm_networks.dart
@@ -1,5 +1,6 @@
 import 'package:rly_network_flutter_sdk/src/gsn/gsn_tx_helpers.dart';
 import 'package:rly_network_flutter_sdk/src/network.dart';
+import 'package:rly_network_flutter_sdk/src/token_helpers.dart';
 import 'package:web3dart/web3dart.dart' as web3;
 
 import '../gsn/utils.dart';
@@ -62,7 +63,7 @@ class NetworkImpl extends Network {
       return balance;
     }
 
-    final decimals = await _decimalsForToken(token);
+    final decimals = await TokenHelpers.getDecimals(tokenAddress, config);
     return balanceToDouble(balance, decimals);
   }
 
@@ -202,15 +203,5 @@ class NetworkImpl extends Network {
         ),
         chainId: 80001);
     return result;
-  }
-
-  Future<BigInt> _decimalsForToken(web3.DeployedContract token) async {
-    final provider = getEthClient(config.gsn.rpcUrl);
-
-    final funCall = await provider.call(
-        contract: token, function: token.function("decimals"), params: []);
-    final decimals = funCall[0] as BigInt;
-
-    return decimals;
   }
 }

--- a/lib/src/token_helpers.dart
+++ b/lib/src/token_helpers.dart
@@ -11,13 +11,14 @@ class TokenHelpers {
       '0xb8c8274f775474f4f2549edcc4db45cbad936fac';
 
   static Future<BigInt> getDecimals(
-      PrefixedHexString tokenAddress, NetworkConfig network) async {
-    final provider = getEthClient(network.gsn.rpcUrl);
+      PrefixedHexString tokenAddress, NetworkConfig config) async {
+    final provider = getEthClient(config.gsn.rpcUrl);
 
     final token = erc20(web3.EthereumAddress.fromHex(tokenAddress));
+    final funCall = await provider.call(
+        contract: token, function: token.function("decimals"), params: []);
+    final decimals = funCall[0] as BigInt;
 
-    final decimals = await provider.call(
-        contract: token, function: token.function('decimals'), params: []);
-    return decimals.first as BigInt;
+    return decimals;
   }
 }

--- a/lib/src/token_helpers.dart
+++ b/lib/src/token_helpers.dart
@@ -5,6 +5,11 @@ import '../contracts.dart';
 import 'network_config/network_config.dart';
 
 class TokenHelpers {
+  static String rlyExecMetaVariantContractAddress =
+      '0x846d8a5fb8a003b431b67115f809a9b9fffe5012';
+  static String rlyExecMetaFaucetContractAddress =
+      '0xb8c8274f775474f4f2549edcc4db45cbad936fac';
+
   static Future<BigInt> getDecimals(
       PrefixedHexString tokenAddress, NetworkConfig network) async {
     final provider = getEthClient(network.gsn.rpcUrl);

--- a/lib/src/token_helpers.dart
+++ b/lib/src/token_helpers.dart
@@ -1,0 +1,18 @@
+import 'package:rly_network_flutter_sdk/src/gsn/utils.dart';
+import 'package:web3dart/web3dart.dart' as web3;
+
+import '../contracts.dart';
+import 'network_config/network_config.dart';
+
+class TokenHelpers {
+  static Future<BigInt> getDecimals(
+      PrefixedHexString tokenAddress, NetworkConfig network) async {
+    final provider = getEthClient(network.gsn.rpcUrl);
+
+    final token = erc20(web3.EthereumAddress.fromHex(tokenAddress));
+
+    final decimals = await provider.call(
+        contract: token, function: token.function('decimals'), params: []);
+    return decimals.first as BigInt;
+  }
+}


### PR DESCRIPTION
Something like getting the decimals for a token is useful outside the context of just our own network implementation. This takes the first step in exposing helper methods such as this to 3rd party devs.

Also adds a place to grab the contract addresses for the alternative implementation of RLY that uses execMetaTxn
