### PR TITLE
Add support for iCloud keychain cloud backup + sync

### DIFF
--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/FlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/FlutterSdkPlugin.kt
@@ -58,6 +58,9 @@ class FlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
         "deleteMnemonic" -> {
           deleteMnemonic(result)
         }
+        "deleteCloudMnemonic" -> {
+          deleteCloudMnemonic(result)
+        }
         "generateNewMnemonic" -> {
           generateNewMnemonic(result)
         }
@@ -101,6 +104,12 @@ class FlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
       result.error("mnemonic_save_failure", message, null)
     })
   }
+
+  private fun deleteCloudMnemonic(result: Result) {
+    mnemonicHelper.deleteFromCloudKeystore(MNEMONIC_STORAGE_KEY)
+    result.success(true)
+  }
+
   private fun deleteMnemonic(result: Result) {
     mnemonicHelper.delete(MNEMONIC_STORAGE_KEY)
     result.success(true)

--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
@@ -75,7 +75,7 @@ class MnemonicStorageHelper(context: Context) {
                 }
         } else {
             if (forceBlockStore) {
-                onFailure("Failed to save mnemonic. No end to end encryption option is available and force cloud is on");
+                onFailure("Failed to save mnemonic. Android Blockstore is unavailable and force cloud is on");
             } else {
                 saveToSharedPref(key, mnemonic)
                 onSuccess()

--- a/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
+++ b/android/src/main/kotlin/com/rly_network/rly_network_flutter_sdk/MnemonicStorageHelper.kt
@@ -21,7 +21,7 @@ class MnemonicStorageHelper(context: Context) {
             isEndToEndEncryptionAvailable = isE2EEAvailable
         }
     }
-    
+
     fun getSharedPreferences(): SharedPreferences {
         val masterKey: MasterKey = Builder(localContext)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -42,7 +42,7 @@ class MnemonicStorageHelper(context: Context) {
             // and recreate them. The user will lose their mnemonic, but this is the only way to
             // recover from this situation.
             localContext.getSharedPreferences(ENCRYPTED_PREFERENCE_FILENAME, Context.MODE_PRIVATE).edit().clear().apply()
-           
+
             attemptedSharedPreferences = EncryptedSharedPreferences.create(
                 localContext,
                 ENCRYPTED_PREFERENCE_FILENAME,
@@ -122,12 +122,19 @@ class MnemonicStorageHelper(context: Context) {
     }
 
     fun delete(key: String) {
+        deleteFromCloudKeystore(key)
+        deleteFromSharedPref(key)
+    }
+
+    fun deleteFromCloudKeystore(key: String) {
         val retrieveRequest = DeleteBytesRequest.Builder()
             .setKeys(listOf(key))
             .build()
 
         blockstoreClient.deleteBytes(retrieveRequest)
+    }
 
+    fun deleteFromSharedPref(key: String) {
         val editor = getSharedPreferences().edit()
         editor.remove(key)
         editor.commit()

--- a/example/lib/account_overview_screen.dart
+++ b/example/lib/account_overview_screen.dart
@@ -97,6 +97,17 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
     widget.onAccountDeleted();
   }
 
+  void switchStorageLocation() async {
+    if (backedUpToCloud == true) {
+      await WalletManager.getInstance().updateWalletStorage(KeyStorageConfig(
+          saveToCloud: false, rejectOnCloudSaveFailure: false));
+    } else {
+      await WalletManager.getInstance().updateWalletStorage(
+          KeyStorageConfig(saveToCloud: true, rejectOnCloudSaveFailure: true));
+    }
+    getWalletBackupState();
+  }
+
   void revealMnemonic() async {
     String? value = await WalletManager.getInstance().getAccountPhrase();
     if (value == null || value.isEmpty) {
@@ -204,6 +215,11 @@ class AccountOverviewScreenState extends State<AccountOverviewScreen> {
                     children: [
                       const Center(
                         child: Text('Manage Your Wallet'),
+                      ),
+                      const SizedBox(height: 12),
+                      FullWidthButton(
+                        onPressed: switchStorageLocation,
+                        child: const Text('Swap Storage Location'),
                       ),
                       const SizedBox(height: 12),
                       FullWidthButton(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,7 +41,7 @@ class AppState extends State<App> {
   Future<void> _createRlyAccount() async {
     final rlyAct = await WalletManager.getInstance().createWallet(
         storageOptions: KeyStorageConfig(
-            rejectOnCloudSaveFailure: false, saveToCloud: false));
+            rejectOnCloudSaveFailure: true, saveToCloud: true));
     setState(() {
       _rlyAccount = rlyAct;
     });

--- a/ios/Classes/FlutterSdkPlugin.swift
+++ b/ios/Classes/FlutterSdkPlugin.swift
@@ -31,6 +31,8 @@ public class FlutterSdkPlugin: NSObject, FlutterPlugin {
           result(RlyNetworkMobileSdk().mnemonicBackedUpToCloud())
         case "deleteMnemonic":
           result(RlyNetworkMobileSdk().deleteMnemonic())
+        case "deleteCloudMnemonic":
+          result(RlyNetworkMobileSdk().deleteCloudMnemonic())
         case "saveMnemonic":
           if let arguments = call.arguments as? [String: Any],
             let mnemonicToSave = arguments["mnemonic"] as? String,

--- a/ios/Classes/KeyChainHelper.swift
+++ b/ios/Classes/KeyChainHelper.swift
@@ -1,22 +1,66 @@
 import Foundation
 
 final class KeychainHelper {
-
     static let standard = KeychainHelper()
     private init() {}
 
     func save(
-      _ data: Data,
-      service: String,
-      account: String,
-      saveToCloud: Bool
+        _ data: Data,
+        service: String,
+        account: String,
+        saveToCloud: Bool
+    ) {
+        if saveToCloud {
+            saveToiCloudKeychain(data, service: service, account: account)
+        } else {
+            saveToDeviceKeychain(data, service: service, account: account)
+        }
+    }
+
+    func saveToiCloudKeychain(
+        _ data: Data,
+        service: String,
+        account: String
+    ) {
+        let query = [
+            kSecValueData: data,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecAttrSynchronizable: true,
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
+        ] as CFDictionary
+
+        // Add data in query to keychain
+        let status = SecItemAdd(query, nil)
+
+        if status == errSecDuplicateItem {
+            // Item already exist, thus update it.
+            let query = [
+                kSecAttrService: service,
+                kSecAttrAccount: account,
+                kSecAttrSynchronizable: true,
+                kSecClass: kSecClassGenericPassword,
+            ] as CFDictionary
+
+            let attributesToUpdate = [kSecValueData: data] as CFDictionary
+
+            // Update existing item
+            SecItemUpdate(query, attributesToUpdate)
+        }
+    }
+
+    func saveToDeviceKeychain(
+        _ data: Data,
+        service: String,
+        account: String
     ) {
         let query = [
             kSecValueData: data,
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
-            kSecAttrAccessible: saveToCloud ? kSecAttrAccessibleWhenUnlocked : kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
         ] as CFDictionary
 
         // Add data in query to keychain
@@ -37,28 +81,39 @@ final class KeychainHelper {
         }
     }
 
-    func readAttributes(service: String, account: String) -> [String: Any]? {
+    func read(service: String, account: String) -> Data? {
+        let iCloudData = readFromiCloudKeychain(service: service, account: account)
+
+        if iCloudData != nil {
+            return iCloudData
+        }
+
+        let localData = readFromDeviceKeychain(service: service, account: account)
+
+        return localData
+    }
+
+    func readFromDeviceKeychain(service: String, account: String) -> Data? {
         let query = [
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
-            kSecReturnAttributes: true
+            kSecReturnData: true,
         ] as CFDictionary
 
         var result: AnyObject?
         SecItemCopyMatching(query, &result)
 
-        return (result as? [String: Any])
+        return (result as? Data)
     }
 
-
-    func read(service: String, account: String) -> Data? {
-
+    func readFromiCloudKeychain(service: String, account: String) -> Data? {
         let query = [
             kSecAttrService: service,
             kSecAttrAccount: account,
+            kSecAttrSynchronizable: true,
             kSecClass: kSecClassGenericPassword,
-            kSecReturnData: true
+            kSecReturnData: true,
         ] as CFDictionary
 
         var result: AnyObject?
@@ -68,12 +123,28 @@ final class KeychainHelper {
     }
 
     func delete(service: String, account: String) {
+        deleteFromDeviceKeychain(service: service, account: account)
+        deleteFromiCloudKeychain(service: service, account: account)
+    }
 
+    func deleteFromDeviceKeychain(service: String, account: String) {
         let query = [
             kSecAttrService: service,
             kSecAttrAccount: account,
             kSecClass: kSecClassGenericPassword,
-            ] as CFDictionary
+        ] as CFDictionary
+
+        // Delete item from keychain
+        SecItemDelete(query)
+    }
+
+    func deleteFromiCloudKeychain(service: String, account: String) {
+        let query = [
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecAttrSynchronizable: true,
+            kSecClass: kSecClassGenericPassword,
+        ] as CFDictionary
 
         // Delete item from keychain
         SecItemDelete(query)

--- a/ios/Classes/RlyNetworkMobileSdk.swift
+++ b/ios/Classes/RlyNetworkMobileSdk.swift
@@ -26,15 +26,9 @@ public class RlyNetworkMobileSdk: NSObject {
     }
 
     public func mnemonicBackedUpToCloud() -> Bool {
-        let mnemonicAttributes = KeychainHelper.standard.readAttributes(service: SERVICE_KEY, account: MNEMONIC_ACCOUNT_KEY)
+        let keyFromiCloudKeychain = KeychainHelper.standard.readFromiCloudKeychain(service: SERVICE_KEY, account: MNEMONIC_ACCOUNT_KEY)
 
-        if (mnemonicAttributes == nil) {
-            return false
-        }
-
-        let keyAccessibility = mnemonicAttributes?[kSecAttrAccessible as String] as? String
-
-        return keyAccessibility == (kSecAttrAccessibleWhenUnlocked as String)
+        return keyFromiCloudKeychain != nil
     }
 
     public func generateMnemonic() -> String {

--- a/ios/Classes/RlyNetworkMobileSdk.swift
+++ b/ios/Classes/RlyNetworkMobileSdk.swift
@@ -70,6 +70,12 @@ public class RlyNetworkMobileSdk: NSObject {
         return true
     }
 
+    public func deleteCloudMnemonic() -> Bool {
+        KeychainHelper.standard.deleteFromiCloudKeychain(service: SERVICE_KEY, account: MNEMONIC_ACCOUNT_KEY)
+
+        return true
+    }
+
     public func getPrivateKeyFromMnemonic(
       _ mnemonic: String
     ) -> Any{

--- a/lib/src/key_manager.dart
+++ b/lib/src/key_manager.dart
@@ -9,6 +9,19 @@ class KeyManager {
     await methodChannel.invokeMethod<bool>("deleteMnemonic");
   }
 
+  /// Removes the mnemonic from the cloud storage. This is a destructive operation.
+  ///
+  /// This is necessary for the case where dev wants to move user storage from cloud to local only.
+  Future<void> deleteCloudMnemonic() async {
+    final bool? status =
+        await methodChannel.invokeMethod<bool>("deleteCloudMnemonic");
+
+    if (status == null || status == false) {
+      throw Exception(
+          "Unable to delete mnemonic from cloud storage, something went wrong at native code layer");
+    }
+  }
+
   Future<String> generateMnemonic() async {
     String? mnemonic =
         await methodChannel.invokeMethod<String>("generateNewMnemonic");

--- a/lib/src/key_storage_config.dart
+++ b/lib/src/key_storage_config.dart
@@ -1,3 +1,15 @@
+/// Configuration for how the wallet key should be stored. This includes whether to save to cloud and whether to reject if saving to cloud fails.
+///
+/// saveToCloud: Whether to save the mnemonic in a way that is eligible for device OS cloud storage. If set to false, the mnemonic will only be stored on device.
+/// rejectOnCloudSaveFailure: Whether to raise an error if saving to cloud fails. If set to false, the mnemonic will silently fall back to local on device only storage.
+///
+/// Please note that when moving from KeyStorageConfig.saveToCloud = false to true, the wallet will be moved to cross device sync. This can overwrite a device only wallet your user might have on a different device.
+/// You should ensure you properly communicate to end users that moving to cloud storage will could cause issues if they currently have different wallets on different devices.
+///
+/// There are several other gotchas to keep in mind when it comes to saveToCloud.
+/// 1. Keys are stored using the OS provided cross device backup mechanism. This mechanism is controlled by user and app preferences and can be disabled by the user or app developer.
+/// 2. On Android, the backup mechanism is Blockstore, which requires user to be logged in to play account and have a device pincode or password set.
+/// 3. On iOS, the backup mechanism is iCloud keychain, which requires user to be logged in to iCloud and have iCloud backup enabled.
 class KeyStorageConfig {
   bool saveToCloud;
   bool rejectOnCloudSaveFailure;

--- a/lib/src/wallet_manager.dart
+++ b/lib/src/wallet_manager.dart
@@ -75,6 +75,8 @@ class WalletManager {
   /// Please note that when moving from KeyStorageConfig.saveToCloud = false to true, the wallet will be moved to device cloud
   /// which will replace a non cloud on device wallet your user might have on a different device. You should ensure you properly
   /// communicate to end users that moving to cloud storage will could cause issues if they currently have different wallets on different devices
+  ///
+  /// If moving from cloud to device only storage, the wallet will be removed from cloud storage and only stored on device. This will remove the wallet from any other devices.
   Future<void> updateWalletStorage(KeyStorageConfig storageOptions) async {
     final mnemonic = await _keyManager.getMnemonic();
     if (mnemonic == null) {
@@ -82,6 +84,10 @@ class WalletManager {
     }
 
     await _keyManager.saveMnemonic(mnemonic, storageOptions: storageOptions);
+
+    if (storageOptions.saveToCloud == false) {
+      await _keyManager.deleteCloudMnemonic();
+    }
   }
 
   Future<Wallet?> getWallet() async {

--- a/lib/src/wallet_manager.dart
+++ b/lib/src/wallet_manager.dart
@@ -41,13 +41,27 @@ class WalletManager {
     return newWallet;
   }
 
-  /// Returns the cloud backup status of the existing wallet.
-  /// Returns false if there is currently no wallet. This method should not be used as a check for wallet existence
+  /// DEPRECATED: Use walletEligibleForCloudSync instead.
+  /// The naming of this method was confusing and has been deprecated in favor of walletEligibleForCloudSync.
+  /// Name implied a level of control over device syncing that is not possible given the operating system constraints. See walletEligibleForCloudSync for more details.
+  Future<bool> walletBackedUpToCloud() async {
+    // ignore: avoid_print
+    print(
+        "walletBackedUpToCloud is deprecated. Use walletCanSyncToOSCloud instead.");
+    return walletEligibleForCloudSync();
+  }
+
+  /// Returns whether the current wallet is stored in a way that is eligible for OS provided cloud backup and cross device sync.
+  /// This is not a guarantee that the wallet is backed up to cloud,
+  /// as the some user & app level settings determine whether secure keys are backed up to device cloud.
+  /// On iOS this is a check whether the wallet will sync if user enables iCloud -> Keychain sync.
+  /// On Android this is a check whether the wallet is in google play keystore and will sync if user enables google backup.
+  /// TRUE response indicates that the wallet will be backed up to OS cloud if user enables the OS provided cloud backup / cross device sync.
+  ///
+  /// This method should not be used as a check for wallet existence
   /// as it will return false if there is no wallet or if the wallet does exist but is not backed up to cloud.
   ///
-  /// If a wallet already exists the reponse will be true or false depending on whether the wallet is backed up to cloud or not.
-  /// TRUE response means wallet is backed up to cloud, FALSE means wallet is not backed up to cloud.
-  Future<bool> walletBackedUpToCloud() async {
+  Future<bool> walletEligibleForCloudSync() async {
     return await _keyManager.walletBackedUpToCloud();
   }
 

--- a/lib/src/wallet_manager.dart
+++ b/lib/src/wallet_manager.dart
@@ -53,7 +53,7 @@ class WalletManager {
 
   /// Returns whether the current wallet is stored in a way that is eligible for OS provided cloud backup and cross device sync.
   /// This is not a guarantee that the wallet is backed up to cloud,
-  /// as the some user & app level settings determine whether secure keys are backed up to device cloud.
+  /// as user & app level settings determine whether secure keys are backed up to device cloud.
   /// On iOS this is a check whether the wallet will sync if user enables iCloud -> Keychain sync.
   /// On Android this is a check whether the wallet is in google play keystore and will sync if user enables google backup.
   /// TRUE response indicates that the wallet will be backed up to OS cloud if user enables the OS provided cloud backup / cross device sync.
@@ -63,6 +63,25 @@ class WalletManager {
   ///
   Future<bool> walletEligibleForCloudSync() async {
     return await _keyManager.walletBackedUpToCloud();
+  }
+
+  /// Updates the storage settings for an existing wallet.
+  /// Accepts a KeyStorageConfig object to specify the storage options for the wallet, same as when creating the wallet
+  ///
+  /// Throws an error if no wallet is found.
+  /// Will reject the promise if the cloud save fails and rejectOnCloudSaveFailure is set to true.
+  /// If rejectOnCloudSaveFailure is set to false, cloud save failure will fallback to on device only storage without rejecting the promise.
+  ///
+  /// Please note that when moving from KeyStorageConfig.saveToCloud = false to true, the wallet will be moved to device cloud
+  /// which will replace a non cloud on device wallet your user might have on a different device. You should ensure you properly
+  /// communicate to end users that moving to cloud storage will could cause issues if they currently have different wallets on different devices
+  Future<void> updateWalletStorage(KeyStorageConfig storageOptions) async {
+    final mnemonic = await _keyManager.getMnemonic();
+    if (mnemonic == null) {
+      throw 'Unable to update storage settings, no wallet found';
+    }
+
+    await _keyManager.saveMnemonic(mnemonic, storageOptions: storageOptions);
   }
 
   Future<Wallet?> getWallet() async {


### PR DESCRIPTION
This addresses the issue where the cloud sync status returned by `WalletManager.walletBackedUpToCloud` on iOS was returning inaccurate & misleading response.
We are now more correctly setting our iOS keychain storage flags for real cloud sync.

Migrating from device only storage to cloud sync storage comes with some end user risk if users have multiple wallets on different devices. Therefore, there
is no auto migration of data. Instead we have exposed a method through WalletManager that allows developers to update the storage config of an existing wallet.


- Update iOS key management to save to iCloud cross device keychain
- Improve method naming for checking whether wallet is eligible for cloud sync
- Add method to update the storage settings on existing wallets
