### PR TITLE
Allow explicit passing of EIP712 Domain Data to support more tokens on Base

### DIFF
--- a/lib/src/network.dart
+++ b/lib/src/network.dart
@@ -1,3 +1,5 @@
+import 'package:eth_sig_util/model/typed_data.dart';
+
 import './networks/evm_networks.dart';
 
 import 'gsn/meta_tx_method.dart';
@@ -19,10 +21,10 @@ abstract class Network {
   Future<BigInt> getExactBalance({PrefixedHexString? tokenAddress});
   Future<String> transfer(
       String destinationAddress, double amount, MetaTxMethod metaTxMethod,
-      {PrefixedHexString? tokenAddress});
+      {PrefixedHexString? tokenAddress, EIP712Domain? eip712DomainData});
   Future<String> transferExact(
       String destinationAddress, BigInt amount, MetaTxMethod metaTxMethod,
-      {PrefixedHexString? tokenAddress});
+      {PrefixedHexString? tokenAddress, EIP712Domain? eip712DomainData});
   Future<String> simpleTransfer(String destinationAddress, double amount,
       {PrefixedHexString? tokenAddress, MetaTxMethod? metaTxMethod});
   Future<String> claimRly();

--- a/lib/src/networks/evm_networks.dart
+++ b/lib/src/networks/evm_networks.dart
@@ -1,3 +1,4 @@
+import 'package:eth_sig_util/model/typed_data.dart';
 import 'package:rly_network_flutter_sdk/src/gsn/gsn_tx_helpers.dart';
 import 'package:rly_network_flutter_sdk/src/network.dart';
 import 'package:rly_network_flutter_sdk/src/token_helpers.dart';
@@ -101,7 +102,7 @@ class NetworkImpl extends Network {
   @override
   Future<String> transfer(
       String destinationAddress, double amount, MetaTxMethod metaTxMethod,
-      {PrefixedHexString? tokenAddress}) async {
+      {PrefixedHexString? tokenAddress, EIP712Domain? eip712DomainData}) async {
     final account = await WalletManager.getInstance().getWallet();
 
     if (account == null) {
@@ -128,13 +129,13 @@ class NetworkImpl extends Network {
         parseUnits(amount.toString(), int.parse(decimals.first.toString()));
 
     return transferExact(destinationAddress, decimalAmount, metaTxMethod,
-        tokenAddress: tokenAddress);
+        tokenAddress: tokenAddress, eip712DomainData: eip712DomainData);
   }
 
   @override
   Future<String> transferExact(
       String destinationAddress, BigInt amount, MetaTxMethod metaTxMethod,
-      {PrefixedHexString? tokenAddress}) async {
+      {PrefixedHexString? tokenAddress, EIP712Domain? eip712DomainData}) async {
     final account = await WalletManager.getInstance().getWallet();
 
     if (account == null) {
@@ -163,6 +164,8 @@ class NetworkImpl extends Network {
         config,
         tokenAddress,
         provider,
+        eip712Salt: eip712DomainData?.salt,
+        eip712Version: eip712DomainData?.version,
       );
     } else {
       transferTx = await getExecuteMetatransactionTx(


### PR DESCRIPTION
- Allow optional EIP 712 domain data to be passed into transfer methods that flows down into permit transaction generation and signing.
- Don't dynamically determine salt via RPC is one is explicitly provided.
  - This improves performance by avoiding unnecessary network calls, and more gracefully handles tokens that lack a eip712Domain contract function


This change is backwards compatible as all arguments are optional, and we fall back to our old way of dynamically determining values from chain rpc calls.

Eventually we will want to move away from any of this dynamic determination, but that would be a breaking change, so should come in future SDK PRs/ versions.
