### PR TITLE
Remove sneaky gas value updates right before relaying txn

### DIFF
--- a/lib/src/gsn/EIP712/permit_transaction.dart
+++ b/lib/src/gsn/EIP712/permit_transaction.dart
@@ -1,4 +1,5 @@
 import 'package:eth_sig_util/util/utils.dart';
+import 'package:rly_network_flutter_sdk/src/gsn/gsn_tx_helpers.dart';
 import 'package:web3dart/web3dart.dart' as web3;
 
 import '../../wallet.dart';
@@ -198,13 +199,8 @@ Future<GsnTransactionDetails> getPermitTx(
 
   final paymasterData =
       '0x${token.address.hex.replaceFirst('0x', '')}${bytesToHex(fromTx)}';
-  //following code is inspired from getFeeData method of
-  //abstract-provider of ethers js library
-  final info = await provider.getBlockInformation();
 
-  final BigInt maxPriorityFeePerGas = BigInt.parse("1500000000");
-  final maxFeePerGas =
-      info.baseFeePerGas!.getInWei * BigInt.from(2) + (maxPriorityFeePerGas);
+  final feeData = await getFeeData(provider);
 
   final gsnTx = GsnTransactionDetails(
     from: wallet.address.hex,
@@ -212,8 +208,8 @@ Future<GsnTransactionDetails> getPermitTx(
     value: "0",
     to: tx.to!.hex,
     gas: "0x${gas.toRadixString(16)}",
-    maxFeePerGas: maxFeePerGas.toString(),
-    maxPriorityFeePerGas: maxPriorityFeePerGas.toString(),
+    maxFeePerGas: feeData.maxFeePerGas!.toRadixString(16),
+    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas!.toRadixString(16),
     paymasterData: paymasterData,
   );
 

--- a/lib/src/gsn/gsn_client.dart
+++ b/lib/src/gsn/gsn_client.dart
@@ -19,7 +19,6 @@ Future<Map<String, dynamic>> updateConfig(
   final serverConfigUpdate = GsnServerConfigPayload.fromJson(response.body);
 
   config.gsn.relayWorkerAddress = serverConfigUpdate.relayWorkerAddress;
-  setGasFeesForTransaction(transaction, serverConfigUpdate);
 
   return {'config': config, 'transaction': transaction};
 }
@@ -159,24 +158,6 @@ Map<String, String> authHeader(NetworkConfig config) {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer ${config.relayerApiKey ?? ''}',
   };
-}
-
-void setGasFeesForTransaction(
-  GsnTransactionDetails transaction,
-  GsnServerConfigPayload serverConfigUpdate,
-) {
-  final serverSuggestedMinPriorityFeePerGas =
-      int.parse(serverConfigUpdate.minMaxPriorityFeePerGas, radix: 10);
-
-  final paddedMaxPriority = (serverSuggestedMinPriorityFeePerGas * 1.4).round();
-  transaction.maxPriorityFeePerGas = paddedMaxPriority.toString();
-
-  // Special handling for mumbai because of quirk with gas estimate returned by GSN for mumbai
-  if (serverConfigUpdate.chainId == '80001') {
-    transaction.maxFeePerGas = paddedMaxPriority.toString();
-  } else {
-    transaction.maxFeePerGas = serverConfigUpdate.maxMaxFeePerGas;
-  }
 }
 
 class GsnServerConfigPayload {

--- a/lib/src/gsn/gsn_tx_helpers.dart
+++ b/lib/src/gsn/gsn_tx_helpers.dart
@@ -255,13 +255,7 @@ Future<GsnTransactionDetails> getClaimTx(
   //abstract-provider of ethers js library
   //test if it exactly replicates the functions of getFeeData
 
-  web3.BlockInformation blockInformation = await client.getBlockInformation();
-  final BigInt maxPriorityFeePerGas = BigInt.parse("1500000000");
-  BigInt? maxFeePerGas;
-  if (blockInformation.baseFeePerGas != null) {
-    maxFeePerGas = blockInformation.baseFeePerGas!.getInWei * BigInt.from(2) +
-        (maxPriorityFeePerGas);
-  }
+  final feeData = await getFeeData(client);
 
   final gsnTx = GsnTransactionDetails(
     from: wallet.address.toString(),
@@ -269,11 +263,36 @@ Future<GsnTransactionDetails> getClaimTx(
     value: "0",
     to: faucet.address.hex,
     gas: "0x${gas.toRadixString(16)}",
-    maxFeePerGas: maxFeePerGas!.toRadixString(16),
-    maxPriorityFeePerGas: maxPriorityFeePerGas.toRadixString(16),
+    maxFeePerGas: feeData.maxFeePerGas!.toRadixString(16),
+    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas!.toRadixString(16),
   );
 
   return gsnTx;
+}
+
+class FeeData {
+  final BigInt? maxFeePerGas;
+  final BigInt? maxPriorityFeePerGas;
+
+  FeeData({this.maxFeePerGas, this.maxPriorityFeePerGas});
+}
+
+Future<FeeData> getFeeData(web3.Web3Client client) async {
+  web3.BlockInformation blockInformation = await client.getBlockInformation();
+  final BigInt maxPriorityFeePerGas = BigInt.parse("1500000000");
+  BigInt? maxFeePerGas;
+
+  if (blockInformation.baseFeePerGas != null) {
+    maxFeePerGas = (blockInformation.baseFeePerGas!.getInWei * BigInt.from(2)) +
+        maxPriorityFeePerGas;
+  }
+
+  print("Got Fee Data");
+
+  return FeeData(
+    maxFeePerGas: maxFeePerGas,
+    maxPriorityFeePerGas: maxPriorityFeePerGas,
+  );
 }
 
 Future<String> getClientId() async {


### PR DESCRIPTION
 In this extra update step we were padding out gas estimation values too much, which causes problems on chains where the gas is paid in eth and you don't want to maintain massive eth balances in all the GSN related on chain addresses.

All estimation now happens in a single place, which is during the transaction construction. This makes the code much easier to follow and reason about. 